### PR TITLE
fix release same conn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+
 go:
   - tip
   - 1.6
@@ -9,4 +13,4 @@ os:
   - linux
   - osx
 
-script: make test
+script: make ci

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 test:
 	go test -race -v ./...
 
+ci:
+	go test -v ./... -covermode=count -coverprofile=coverage.out
+	$(HOME)/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $(COVERALLS_TOKEN)
+
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 > A Golang TCP connection pool
 
 [![Build Status](https://travis-ci.org/ibigbug/conn-pool.svg?branch=master)](https://travis-ci.org/ibigbug/conn-pool)
+[![Coverage Status](https://coveralls.io/repos/github/ibigbug/conn-pool/badge.svg)](https://coveralls.io/github/ibigbug/conn-pool)

--- a/connpool/pool.go
+++ b/connpool/pool.go
@@ -94,8 +94,13 @@ func (p ConnectionPool) Release(conn *ManagedConn) {
 		for _, c := range p.pool[remoteAddr] {
 			debug("%p, ", c)
 		}
-		fmt.Println()
+		debug("")
 		idx := findIdx(p.pool[remoteAddr], conn)
+
+		if idx == -1 {
+			// conn has already been released
+			return
+		}
 		p.pool[remoteAddr] = append(p.pool[remoteAddr][:idx], p.pool[remoteAddr][idx+1:]...)
 		conn.Close()
 	}()


### PR DESCRIPTION
Fix a situation when two go routine are trying to release the same conn
